### PR TITLE
Add secondary check to confirm member left/failed

### DIFF
--- a/failover-handler.py
+++ b/failover-handler.py
@@ -205,7 +205,7 @@ def log(message, level=logging.INFO):
 
 def is_member_down(member_ip):
     result = -1
-    total_retries = 5
+    total_retries = 3
     while total_retries > 0:
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -217,7 +217,7 @@ def is_member_down(member_ip):
         finally:
             log("Retrying, checking if member is down, status_code=%s" % result)
             total_retries -= 1
-            time.sleep(3)
+            time.sleep(1)
     return False if result == 0 else True
 
 


### PR DESCRIPTION
Sometimes because of remote aws regions, serf falsely detects a member has failed/ left the cluster. This is because it has a very very short time span when it expects to receive a ping back from members in the cluster.

This PR adds a secondary check to be sure that the the serf member that reported to have been failed is really down.
